### PR TITLE
docs: add README with Quick Start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,69 @@
 # Aegis: Scalable Privacy-preserving CBDC Framework with Dynamic Proof of Liabilities
 
+
+<p align="center">
+  <a href="https://eprint.iacr.org/2025/539">
+    <img src="https://img.shields.io/badge/IACR%20ePrint-2025%2F539-informational.svg" alt="IACR ePrint 2025/539">
+  </a>
+  &nbsp;
+  <a href="https://github.com/arkworks-rs/groth16/blob/master/LICENSE-MIT">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License">
+  </a>
+</p>
+
+> ℹ️ **Note:**
+> This repository contains a implementation of [**Aegis**](https://your-link.example).
+
+> ⚠️ **Warning:**
+> Do not use this project in production.  
+
+
+
+## Abstract
+
+## Quick Start
+> This repository contains both Rust/arkworks circuits and Hardhat-based smart contracts.
+> Follow the steps below to reproduce the full testing pipeline locally.
+
+### 0. Environments
+- Rust (stable): `cargo`
+- Node.js (LTS): `npm`
+- Git, bash
+
+### 1. Clone & Install
+```bash
+git clone https://github.com/snp-labs/Aegis.git
+cd aegis
+```
+
+### 2. Environment Setup
+Before running circuit tests, copy the example environment file:
+```bash
+cp env.example .env
+```
+Make sure to adjust any required values in .env according to your setup.
+
+
+### 3. Circuit Tests
+```bash
+cd aegis_circuit/src/tests
+sh run_tests.sh
+```
+- This file includes detailed performance metrics, such as:
+  - Number of Constraints
+  - Setup time
+  - Proving time
+  - Aggregate time
+  - Verify time
+  - Performance across different batch sizes and thread counts
+- Results are stored in `circuit_result.txt`
+
+### 4. Smart Contract Tests
+Before running contract tests, make sure you have run Circuit Tests (Step 3).
+Circuit tests generate scenario data required for the contracts (`aegis_contract/result/dbtData.ts`)
+```bash
+cd aegis_contract
+npm install
+npx hardhat test
+```
+- Tests will fall if `dbtData.ts` is missing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 > ℹ️ **Note:**
-> This repository contains a implementation of [**Aegis**](https://your-link.example).
+> This repository contains a implementation of [**Aegis**](https://eprint.iacr.org/2025/539).
 
 > ⚠️ **Warning:**
 > Do not use this project in production.  


### PR DESCRIPTION
Added a Quick Start guide to the README with instructions for running circuit and contract tests.